### PR TITLE
Enable csv log download, mobile css

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,9 +6,11 @@
     <title>NTI XL2 Web Interface</title>
     <script src="/socket.io/socket.io.js"></script>
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
-          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
           crossorigin=""/>
+    <link rel="stylesheet" href="css/styles.css">
+    <link rel="stylesheet" href="css/mobile.css">
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" 
@@ -990,10 +992,11 @@
                 <div class="button-group">
                     <button onclick="startLogging()" id="startLogBtn" class="btn btn-success">▶️ Start Logging</button>
                     <button onclick="stopLogging()" id="stopLogBtn" class="btn btn-warning" disabled>⏹️ Stop Logging</button>
+                    <a href="/logs/xl2_measurements.csv" id="downloadCsvBtn" class="btn btn-secondary" download>⬇️ Download CSV</a>
                 </div>
                 <div class="alert alert-info" style="margin-top: 10px; font-size: 0.9em;">
                     📊 Logs: Datum, Uhrzeit, 12.5Hz Pegel, GPS Koordinaten<br>
-                    📁 Files saved to: <code>logs/Log_YYYY-MM-DD-HH-mm-ss.csv</code>
+                    📁 File saved to: <code>logs/xl2_measurements.csv</code>
                 </div>
             </div>
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -295,6 +295,19 @@ class XL2Application {
             const welcomeMessage = isMobile ? 'XL2 Interface ready' : 'XL2 Web Interface ready';
             ui.showToast(welcomeMessage, 'success');
 
+            // Update CSV download link with latest log file if available
+            fetch(CONFIG.API.LOGS)
+                .then(res => res.json())
+                .then(result => {
+                    if (result.success && result.data.length > 0) {
+                        const link = document.getElementById('downloadCsvBtn');
+                        if (link) {
+                            link.href = `/logs/${result.data[0]}`;
+                        }
+                    }
+                })
+                .catch(() => {});
+
         } catch (error) {
             console.error('❌ Window load handler failed:', error);
             ui.showToast('Initialization error', 'error');

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -110,7 +110,8 @@ const CONFIG = {
         MEASUREMENTS: '/api/measurements',
         MEASUREMENTS_12_5HZ: '/api/measurements/12_5hz',
         CSV_DATA: '/api/csv-data',
-        EXPORT_CSV: '/api/export-csv'
+        EXPORT_CSV: '/api/export-csv',
+        LOGS: '/api/logs'
     },
 
     // WebSocket Events

--- a/server.js
+++ b/server.js
@@ -172,6 +172,7 @@ class XL2WebServer {
 
     // Static file serving
     this.app.use(express.static(this.config.paths.public));
+    this.app.use('/logs', express.static(this.config.paths.logs));
 
     logger.info('✅ Express application configured');
   }

--- a/src/routes/apiRoutes.js
+++ b/src/routes/apiRoutes.js
@@ -9,6 +9,8 @@ import { HTTP_STATUS } from '../constants.js';
 import { logger } from '../utils/logger.js';
 import { ErrorHandler, asyncHandler } from '../utils/errors.js';
 import { validateRequest } from '../utils/validation.js';
+import fs from 'fs';
+import path from 'path';
 
 /**
  * Create API routes
@@ -220,11 +222,24 @@ export function createApiRoutes(xl2, gpsLogger, generatePathFromCSV) {
 
   router.get('/logging/status', asyncHandler(async (req, res) => {
     const status = gpsLogger.getStatus().logging;
-    
+
     res.json({
       success: true,
       data: status
     });
+  }));
+
+  // List CSV log files
+  router.get('/logs', asyncHandler(async (req, res) => {
+    try {
+      const logsDir = path.join(process.cwd(), 'logs');
+      const files = await fs.promises.readdir(logsDir);
+      const csvFiles = files.filter(f => f.toLowerCase().endsWith('.csv'));
+      res.json({ success: true, data: csvFiles });
+    } catch (error) {
+      logger.error('Error reading log directory', error);
+      res.json({ success: false, message: 'Failed to read logs' });
+    }
   }));
 
   // CSV data endpoints


### PR DESCRIPTION
## Summary
- serve `logs/` as static files
- list available csv logs via new endpoint
- include desktop/mobile stylesheets and download button
- configure API constant and update link after load

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d172b26808321b55ea2c528aff17d